### PR TITLE
Add workaround for a url pattern matching bug

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,3 +1,18 @@
+## Development setup
+
+* Use python3.9 or earlier.
+  
+* `sudo apt-get install -y python3-dev graphviz libgraphviz-dev pkg-config python3-venv postgresql libpq-dev libxml2-dev libxslt-dev virtualenvwrapper`
+* clone the project and enter the project directory
+* `python -m venv env`
+* `. env/bin/activate`
+* `pip install --upgrade setuptools`
+* `pip install -r requirements.txt -r requirements_local.txt -r requirements_test.txt`
+* create `wikiwho_api/settings.py`
+* set up the database
+* run a server with `python manage.py runserver
+
+
 ## Notes from trying to stand up app
 
 ### Requirements

--- a/whocolor/views.py
+++ b/whocolor/views.py
@@ -58,6 +58,15 @@ class WhoColorApiView(LoggingMixin, APIView):
         self.page_id = page_id
 
     def get(self, request, version, page_title, rev_id=None):
+        # This is a workaround for titles that have a `/` in them.
+        # You can pass rev_id 0 and it will treat it the same way as if no rev_id was passed.
+        # This is necessary for page titles like "Post-9/11" where — even when encoded as "%2f" —
+        # the slash in the title causes the urlpattern to mis-match the title as a truncated title
+        # followed by a rev_id.
+        # For example, /en/whocolor/v1.0.0-beta/Post-9%2f11/0/?origin=* will work for "Post-9/11".
+        if (rev_id == '0'):
+            rev_id = None
+
         response = {}
         try:
             language = get_language()


### PR DESCRIPTION
Currently, the wikiwho api server mishandles requests without a rev_id when there is a slash in the page title (even if it's url-encoded). Here's the known example: https://wikiwho.wmflabs.org/en/whocolor/v1.0.0-beta/Post-9%2f11/?origin=*

It treats it as title "Post-9" and revision ID 11 (and returns a 404). This means Wiki Education Dashboard can't show authorship data for the article "Post-9/11".

When a rev_id is included, the url pattern matching works as intended, even when the slash in the page title isn't url-encoded: https://wikiwho.wmflabs.org/en/whocolor/v1.0.0-beta/Post-9/11/1107562740/?origin=*

This workaround will let me update the Dashboard to add `/0` (ie, rev_id 0) to requests and have it work the same way as when no rev_id is supplied (ie, in that case it will find and return data for the most recent revision).