### PR TITLE
Use mediawiki.revision-visibility-change stream to detect revdel

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -57,4 +57,5 @@ Instead of the complex instructions for running Celery from the wiki, you can ru
 
 1. [Install RabbitMQ](https://www.rabbitmq.com/download.html). Linux users should be okay to install with just `sudo apt-get rabbitmq-server`.
 2. Within the virtual env, start celery with `celery -A wikiwho_api worker --loglevel=INFO`
-3. If you need to test with EventStreams, start that worker with `python manage.py celery_changed_articles`
+3. If you need to test with EventStreams, start that worker with `python manage.py celery_changed_articles`,
+   and another worker for the revision deletion events with `python manage.py celery_deletion_events`.

--- a/WIKIMEDIA_VPS_SETUP.md
+++ b/WIKIMEDIA_VPS_SETUP.md
@@ -62,8 +62,10 @@
     2.  `sudo systemctl start ww_flower.service`
     3.  `sudo systemctl status ww_flower.service` to check if it's running
     4.  `sudo systemctl enable ww_events_stream.service`
-    5.  `systemctl start ww_events_stream.service`
-    6.  `systemctl status ww_events_stream.service` to check if it's running
+    5.  `sudo systemctl start ww_events_stream.service`
+    6.  `sudo systemctl status ww_events_stream.service` to check if it's running
+    7.  `sudo systemctl start ww_events_stream_deletion.service`
+    8.  `sudo systemctl status ww_events_stream_deletion.service` to check if it's running
 
 # Adding new languages to WikiWho
 

--- a/api/management/commands/celery_deletion_events.py
+++ b/api/management/commands/celery_deletion_events.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+from api.utils_celery import process_deletion_events
+
+
+class Command(BaseCommand):
+    help = "Get event streams of deletion events from wikimedia and create tasks to delete the associated pickle files."
+
+    def handle(self, *args, **options):
+        process_deletion_events()

--- a/api/utils_celery.py
+++ b/api/utils_celery.py
@@ -6,8 +6,8 @@ from deployment.celery_config import worker_name_default, worker_name_user
 from django.conf import settings
 
 from base.utils_log import get_base_logger, get_stream_base_logger
-from .events_stream import iter_changed_pages
-from .tasks import process_article, process_article_deletion
+from .events_stream import iter_changed_pages, iter_deletion_events
+from .tasks import process_article, process_article_deletion, process_article_deletion_from_log_id
 
 # worker_name = app.control.inspect().ping().popitem()[0]
 # give name of the worker to speed up
@@ -20,6 +20,7 @@ inspector = app.control.inspect([worker_name_default, worker_name_user])
 
 logger = get_base_logger('events_streamer', settings.EVENTS_STREAM_LOG, level=logging.WARNING)
 streamer = get_stream_base_logger('streamer', level=logging.DEBUG)
+
 
 def get_active_task_pages():
     """Return page titles of tasks that are running right now."""
@@ -64,9 +65,15 @@ def process_changed_articles():
         # Delete pickle file if the page is deleted.
         if change.get('type') == 'log' and change.get('log_type') == 'delete' and change.get('log_action') == 'delete':
             streamer.info(f"EVENT (delete): {page_title} ({language})")
-            process_article_deletion.delay(language, page_title, change.get('log_id'))
+            process_article_deletion_from_log_id.delay(language, page_title, change.get('log_id'))
         # Otherwise, queue the article for processing
         elif page_title not in get_inactive_task_pages():
             streamer.info(f"EVENT ({change.get('type')}): {page_title} ({language})")
             # if already not registered to celery
             process_article.delay(language, page_title)
+
+
+def process_deletion_events():
+    for language, page_id in iter_deletion_events(logger):
+        streamer.info(f"DELETION EVENT: {page_id} ({language})")
+        process_article_deletion(language, page_id)

--- a/wikimedia_cloud_customization_script.sh
+++ b/wikimedia_cloud_customization_script.sh
@@ -153,5 +153,21 @@ ExecStart=/home/wikiwho/wikiwho_api/env/bin/python manage.py celery_changed_arti
 WantedBy=multi-user.target
 """ > /etc/systemd/system/ww_events_stream.service
 
+# Add deletion stream listening service
+echo """
+[Unit]
+Description=revision-visibility-change daemon
+After=network.target
+
+[Service]
+User=wikiwho
+Group=www-data
+WorkingDirectory=/home/wikiwho/wikiwho_api
+ExecStart=/home/wikiwho/wikiwho_api/env/bin/python manage.py celery_deletion_events
+
+[Install]
+WantedBy=multi-user.target
+""" > /etc/systemd/system/ww_events_stream_deletion.service
+
 mkdir /var/log/django/events_streamer
 chown wikiwho:www-data /var/log/django/events_streamer


### PR DESCRIPTION
Delete pickle files after revision deletion occurs.

This also capture suppression events, which aren't logged to the normal
recentchange event stream.

Bug: T333344