### PR TITLE
Delete pickle file after article has been deleted

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -251,6 +251,25 @@ def get_revision_timestamp(revision_ids, language):
     return [timestamps[rev_id] for rev_id in revision_ids]
 
 
+def get_page_id_from_deletion_log_id(page_title, language, log_id):
+    params = {
+        'action': 'query',
+        'list': 'logevents',
+        'leprop': 'ids',
+        'letype': 'delete',
+        'letile': page_title,
+        'format': 'json',
+    }
+    resp_ = requests.get(get_wp_api_url(language),
+                         params=params, headers=settings.WP_HEADERS)
+    response = resp_.json()
+    events = response['query'].get('logevents')
+    for event in events:
+        if event['logid'] == log_id:
+            return event['logpage']
+    return None
+
+
 class Timeout:
 
     def __init__(self, seconds=1, error_message='Timeout'):
@@ -270,7 +289,7 @@ class Timeout:
 
 def generate_rvcontinue(language, rev_id, rev_ts=None):
     """
-    :param rev_id: Revision id, must be integer. 
+    :param rev_id: Revision id, must be integer.
     :param rev_ts: revision timestamp, must be string representation.
     :return: rvcontinue
     """

--- a/api/utils_pickles.py
+++ b/api/utils_pickles.py
@@ -5,6 +5,7 @@ import io
 import fcntl
 import errno
 from os.path import getsize
+from os import remove
 
 from six.moves import cPickle as pickle
 from six.moves.cPickle import UnpicklingError
@@ -87,6 +88,17 @@ def pickle_load(pickle_path):
             time.sleep(0.1)
             if not retries:
                 raise e
+
+
+def pickle_delete(page_id, language):
+    pickle_path = "{}/{}.p".format(get_pickle_folder(language), page_id)
+    try:
+        remove(pickle_path)
+    except Exception as e:
+        # TODO: add a logging channel for utils_pickles
+        # Simply silently ignore for now.
+        return False
+    return True
 
 
 def pickle_load_only_id(page_id, language=None):

--- a/deployment/celery_config.py
+++ b/deployment/celery_config.py
@@ -43,6 +43,9 @@ task_routes = {
             'queue': 'long',
             'routing_key': 'long',
         },
+        'api.tasks.process_article_deletion': {
+            'queue': 'default',
+        }
 }
 
 # How many messages to prefetch at a time multiplied by the number of concurrent processes.

--- a/wikiwho_api/settings_base.py
+++ b/wikiwho_api/settings_base.py
@@ -198,7 +198,7 @@ SWAGGER_SETTINGS = {
 #     'DEFAULT_CACHE_ERRORS': False
 # }
 
-ACTIONS_LANGUAGES = ['tr', 'eu', 'es', 'de', 'en', 'fr', 'it', 'hu', 'id', 'ja', 'pt', 'nl']
+ACTIONS_LANGUAGES = ['de', 'en', 'es', 'eu', 'fr', 'hu', 'id', 'it', 'ja', 'nl', 'pt', 'tr']
 CRONJOBS = [
     ('0 1 3 * *', 'api_editor.cron.update_actions_tables', f'>> /dev/null 2>> /var/log/django/crontab.log')
 ]
@@ -257,3 +257,5 @@ SERVER_LEVEL = LEVEL_LOCAL
 
 CHOBS_CONTEXT = 5
 CHOBS_LANGUAGES = ('de')
+
+EVENT_STREAM_WIKIS = ['dewiki', 'enwiki', 'eswiki', 'euwiki', 'frwiki', 'huwiki', 'itwiki', 'trwiki']

--- a/wikiwho_api/settings_wmcloud.py
+++ b/wikiwho_api/settings_wmcloud.py
@@ -18,20 +18,21 @@ ALLOWED_HOSTS = ['wikiwho-api.wmcloud.org', 'wikiwho.wmflabs.org']
 
 ONLY_READ_ALLOWED = False
 
-ACTIONS_LANGUAGES = ['tr', 'eu', 'es', 'de', 'en', 'fr', 'it', 'hu', 'id', 'ja', 'pt', 'nl']
+ACTIONS_LANGUAGES = ['de', 'en', 'es', 'eu', 'fr', 'hu', 'id', 'it', 'ja', 'nl', 'pt', 'tr']
+EVENT_STREAM_WIKIS = ['dewiki', 'enwiki', 'eswiki', 'euwiki', 'frwiki', 'huwiki', 'itwiki', 'nlwiki', 'trwiki']
 
 # On pickle_storage volume, mounted to /pickles
-PICKLE_FOLDER_EN = '/pickles/en'
-PICKLE_FOLDER_EU = '/pickles/eu'
-PICKLE_FOLDER_ES = '/pickles/es'
 PICKLE_FOLDER_DE = '/pickles/de'
+PICKLE_FOLDER_EN = '/pickles/en'
+PICKLE_FOLDER_ES = '/pickles/es'
+PICKLE_FOLDER_EU = '/pickles/eu'
 PICKLE_FOLDER_TR = '/pickles/tr'
 
 # On pickle_storage02 volume, mounted to /pickles-02
 PICKLE_FOLDER_FR = '/pickles-02/fr'
-PICKLE_FOLDER_IT = '/pickles-02/it'
 PICKLE_FOLDER_HU = '/pickles-02/hu'
 PICKLE_FOLDER_ID = '/pickles-02/id'
+PICKLE_FOLDER_IT = '/pickles-02/it'
 PICKLE_FOLDER_JA = '/pickles-02/ja'
 PICKLE_FOLDER_PT = '/pickles-02/pt'
 PICKLE_FOLDER_NL = '/pickles-02/nl'


### PR DESCRIPTION
This also fixes a bug where the language code is assumed to be the
first two characters of the domain name. Change this to go by the
server_name from EventStreams (which is the domain), and use the
subdomain as the language code.
    
The db list for event streams has been moved to the EVENT_STREAMS_WIKIS
setting, and the language lists have been alphabetized.
    
Bug: T333390