### PR TITLE
Change logo link, add more context to home page

### DIFF
--- a/templates/home/home.html
+++ b/templates/home/home.html
@@ -78,7 +78,7 @@
 <nav class="navbar navbar-inverse navbar-fixed-top">
     <div class="container">
         <div class="navbar-header">
-            <a class="navbar-brand" href="https://www.wikiwho.net/">
+            <a class="navbar-brand" href="https://wikiwho-api.wmcloud.org/">
                 <img alt="WikiWho" width="60" src="{% static 'images/logo_white.png' %}">
             </a>
         </div>
@@ -138,7 +138,8 @@
     <div class="row">
         {% block content %}
             <div>
-              This is Wikimedia's WikiWho API service. The API and the WikiWho algorithms were originally developed by <a href="https://www.gesis.org/">GESIS</a>; for more details, see the <a href="/gesis_home">original homepage</a>.
+              <p>This is Wikimedia's WikiWho API service. The API and the WikiWho algorithms were originally developed by <a href="https://www.gesis.org/">GESIS</a>; for more details, see the <a href="/gesis_home">original homepage</a>.</p>
+              <p>WikiWho was first conceived as a dissertation project at <a href="https://www.kit.edu/english/">Karlsruhe Institute of Technology</a> by Dr. Fabian Flöck. It was hosted, maintained and further developed at the <a href="https://www.gesis.org/institut/abteilungen/computational-social-science">Computational Social Sciences (CSS) department</a> of <a href="https://www.gesis.org/home">GESIS – Leibniz Institute for the Social Sciences</a>.</p>
             </div>
         {% endblock content %}
     </div>


### PR DESCRIPTION
The new text was requested by Roberto Ulloa, who has been in charge of wikiwho.net until it was recently taken offline.