### PR TITLE
wikimedia_cloud_customization_script: add tmpfiles.d config for celery

### DIFF
--- a/wikimedia_cloud_customization_script.sh
+++ b/wikimedia_cloud_customization_script.sh
@@ -43,6 +43,11 @@ rabbitmqctl set_permissions -p ww_vhost ww_worker ".*" ".*" ".*"
 rabbitmq-plugins enable rabbitmq_management
 rabbitmq-server -detached
 
+# Register creation of the /var/run/celery directory on reboot
+echo """
+d /var/run/celery 0755 wikiwho wikiwho -
+""" > /etc/tmpfiles.d/celery.conf
+
 # Add Celery config
 cat /home/wikiwho/wikiwho_api/deployment/ww_celery.service > /etc/systemd/system/ww_celery.service
 


### PR DESCRIPTION
This will ensure the /var/run/celery directory is recreated when the VM is rebooted.

I've already added /etc/tmpfiles.d/celery.conf to our instance.